### PR TITLE
Fix pages variable check

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -61,7 +61,7 @@
                 <li><a href="{{ link }}">{{ title }}</a></li>
         {% endfor %}
 
-        {% if DISPLAY_PAGES_ON_MENU and PAGES %}
+        {% if DISPLAY_PAGES_ON_MENU and pages %}
             {% for p in pages %}
                 <li><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
             {% endfor %}


### PR DESCRIPTION
Fix uppercase PAGES variable after Pelican made a breaking change to require lowercase:

http://docs.getpelican.com/en/stable/faq.html#since-i-upgraded-pelican-my-pages-are-no-longer-rendered