### PR TITLE
Adds "SPREAD_THE_WORD" toggle

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -36,7 +36,9 @@
     </mainarticle>
 </div>
 <hr>
-        
+
+<!--Add SPREAD_THE_WORD = False to your pelicanconf.py to remove this section from your posts.-->
+{% if SPREAD_THE_WORD %}
 <div>
         <i>If you found the article helpful, please share or cite the article, and spread the word:</i>
             <p style="margin-top: 2%;">
@@ -47,6 +49,8 @@
             </p>
 </div>
 <hr>
+{% endif %}
+
 {% if AUTHOREMAIL %}
     <p><i>For any feedback or corrections, please write in to: </i><b> {{ AUTHOREMAIL }} </b></p>
 {% else  %}


### PR DESCRIPTION
Adding `SPREAD_THE_WORD = False` to your `pelicanconf.py` will remove the "spread the word" section from your posts.